### PR TITLE
ci: dependabot use groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Group all CI dependencies into a single PR
+    groups:
+      ci:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Group all Python dependencies into a single PR
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+        - "minor"
+        - "patch"


### PR DESCRIPTION
Group Actions PRs into a single PR and use a single PR for minor and patch updates of python packages.