### PR TITLE
build: update cmake during build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.23.0
 
       - name: Make wheels Pythonless
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v3.1.4
 
       - name: Make wheels Pythonless
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           - { os: windows-latest, shell: bash }
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-14, shell: bash }
+          - { os: macos-13, shell: bash } # Intel runner
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         sys:
           - { os: windows-latest, shell: bash }
           - { os: ubuntu-latest, shell: bash }
-          - { os: macos-latest, shell: bash }
+          - { os: macos-14, shell: bash }
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=80",
     "scikit-build>=0.13",
-    "cmake>=3.18",
+    "cmake>=4.1.0",
     "ninja",
     "setuptools_scm>=8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ skip = "pp*"      # skip all pypy builds
 
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["universal2", "arm64"]
 
 [tool.cibuildwheel.macos.environment]
 CC = "clang"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ archs = ["auto"]
 [tool.cibuildwheel.macos.environment]
 CC = "clang"
 CXX = "clang++"
-# MACOSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ CXX = "clang++"
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto64", "auto32"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,12 @@ skip = "pp*"      # skip all pypy builds
 
 
 [tool.cibuildwheel.macos]
-archs = ["universal2", "arm64"]
+archs = ["arm64"]
 
 [tool.cibuildwheel.macos.environment]
 CC = "clang"
 CXX = "clang++"
+# MACOSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ skip = "pp*"      # skip all pypy builds
 
 
 [tool.cibuildwheel.macos]
-archs = ["arm64"]
+archs = ["auto"]
 
 [tool.cibuildwheel.macos.environment]
 CC = "clang"


### PR DESCRIPTION
Doing this since the CI runner appears to be unable
to locate a valid wheel for cmake, even though it should
have one. It then attempts to build from source and it
failes when OpenSSL is not installed in the containerised
runner.
